### PR TITLE
Fix duplicate distractor options

### DIFF
--- a/internal/csv/handler.go
+++ b/internal/csv/handler.go
@@ -179,27 +179,29 @@ func createMultipleChoiceQuestionFromAnswers(question, correctAnswer string, all
 func getRandomDistractors(correctAnswer string, allAnswers []string, seed int) []string {
 	r := rand.New(rand.NewSource(time.Now().UnixNano() + int64(seed*13)))
 
-	var distractors []string
 	var otherAnswers []string
+	unique := make(map[string]struct{})
 
 	for _, answer := range allAnswers {
 		if answer != correctAnswer {
-			otherAnswers = append(otherAnswers, answer)
+			if _, exists := unique[answer]; !exists {
+				unique[answer] = struct{}{}
+				otherAnswers = append(otherAnswers, answer)
+			}
 		}
 	}
 
-	if len(otherAnswers) > 0 {
-		r.Shuffle(len(otherAnswers), func(i, j int) {
-			otherAnswers[i], otherAnswers[j] = otherAnswers[j], otherAnswers[i]
-		})
-
-		maxDistractors := len(otherAnswers)
-		if maxDistractors > 3 {
-			maxDistractors = 3
-		}
-
-		distractors = otherAnswers[:maxDistractors]
+	if len(otherAnswers) == 0 {
+		return []string{}
 	}
 
-	return distractors
+	r.Shuffle(len(otherAnswers), func(i, j int) {
+		otherAnswers[i], otherAnswers[j] = otherAnswers[j], otherAnswers[i]
+	})
+
+	if len(otherAnswers) > 3 {
+		otherAnswers = otherAnswers[:3]
+	}
+
+	return otherAnswers
 }

--- a/internal/models/quiz.go
+++ b/internal/models/quiz.go
@@ -119,6 +119,22 @@ func (m Model) HandleMenuUpdate(msg tea.KeyMsg) (Model, tea.Cmd) {
 }
 
 func (m Model) HandleQuestionUpdate(msg tea.KeyMsg) (Model, tea.Cmd) {
+	if len(m.Questions) == 0 {
+		switch msg.String() {
+		case "ctrl+c":
+			return m, tea.Quit
+		case "q":
+			m.State = StateMenu
+			m.Cursor = 0
+			m.CurrentQ = 0
+			m.InputText = ""
+			m.CorrectCount = 0
+			return m, nil
+		default:
+			return m, nil
+		}
+	}
+
 	switch msg.String() {
 	case "ctrl+c", "q":
 		return m, tea.Quit

--- a/internal/ui/common.go
+++ b/internal/ui/common.go
@@ -18,7 +18,7 @@ func RenderEmptyQuestionsError() string {
 	s += "Please check that your CSV file is properly formatted:\n"
 	s += "- Each line should have: question,answer\n"
 	s += "- Questions and answers should not be empty\n\n"
-	s += lipgloss.NewStyle().Faint(true).Render("q: Exit to main menu")
+	s += lipgloss.NewStyle().Faint(true).Render("q: Back to menu")
 
 	return s
 }


### PR DESCRIPTION
## Summary
- deduplicate distractor answers when generating multiple choice questions

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6846bee03c3c8324b47839060d8ae2bf